### PR TITLE
Quantity basics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,7 @@ extend-select = [
   "ARG",      # flake8-unused-arguments
   "B",        # flake8-bugbear
   "C4",       # flake8-comprehensions
-  "EM",       # flake8-errmsg
-  "EXE",      # flake8-executable
+  "E",        # errors
   "G",        # flake8-logging-format
   "I",        # isort
   "ICN",      # flake8-import-conventions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ authors = [
     { name = "The Astropy Developers", email = "astropy.team@gmail.com" }
 ]
 dependencies = [
-  "array-api-compat",
-  "astropy",
+  "array-api-compat>=1.9.1",
+  "astropy>=7.0",
   "numpy>=2.0",
 ]
 dynamic = ["version"]
@@ -24,8 +24,8 @@ dynamic = ["version"]
 [project.optional-dependencies]
 # Include other array types than numpy/array-api-strict. Mostly for tests.
 all = [
-    "dask",
-    "jax",
+    "dask>=2024.11.2",
+    "jax>=0.4.35",
 ]
 test = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,22 @@ authors = [
     { name = "The Astropy Developers", email = "astropy.team@gmail.com" }
 ]
 dependencies = [
+  "array-api-compat",
   "astropy",
   "numpy>=2.0",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
+# Include other array types than numpy/array-api-strict. Mostly for tests.
+all = [
+    "dask",
+]
 test = [
     "pytest",
     "pytest-doctestplus",
-    "pytest-cov"
+    "pytest-cov",
+    "array-api-strict",
 ]
 docs = [
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ license = { file = "licenses/LICENSE.rst" }
 authors = [
     { name = "The Astropy Developers", email = "astropy.team@gmail.com" }
 ]
-dependencies = []
+dependencies = [
+  "astropy",
+  "numpy>=2.0",
+]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dynamic = ["version"]
 # Include other array types than numpy/array-api-strict. Mostly for tests.
 all = [
     "dask",
+    "jax",
 ]
 test = [
     "pytest",

--- a/quantity/__init__.py
+++ b/quantity/__init__.py
@@ -1,5 +1,12 @@
+"""
+Copyright (c) 2024 Astropy Developers. All rights reserved.
+
+quantity-2.0: Prototyping the next generation Quantity
+"""
+
 from __future__ import annotations
 
+from .core import Quantity
 from .version import version as __version__  # noqa: F401
 
-__all__ = []
+__all__ = ["Quantity"]

--- a/quantity/core.py
+++ b/quantity/core.py
@@ -1,0 +1,231 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import annotations
+
+import operator
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
+
+import astropy.units as u
+import numpy as np
+from astropy.units.quantity_helper import UFUNC_HELPERS
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+DIMENSIONLESS = u.dimensionless_unscaled
+
+PYTHON_NUMBER = float | int | complex
+
+
+def get_value_and_unit(arg, default_unit=None):
+    # HACK: interoperability with astropy Quantity.  Have protocol?
+    try:
+        unit = arg.unit
+    except AttributeError:
+        return arg, default_unit
+    else:
+        return arg.value, unit
+
+
+def value_in_unit(value, unit):
+    v_value, v_unit = get_value_and_unit(value, default_unit=DIMENSIONLESS)
+    return v_unit.to(unit, v_value)
+
+
+_OP_TO_NP_FUNC = {
+    "__add__": np.add,
+    "__floordiv__": np.floor_divide,
+    "__matmul__": np.matmul,
+    "__mod__": np.mod,
+    "__mul__": np.multiply,
+    "__sub__": np.subtract,
+    "__truediv__": np.true_divide,
+}
+OP_HELPERS = {op: UFUNC_HELPERS[np_func] for op, np_func in _OP_TO_NP_FUNC.items()}
+
+
+def _make_op(fop, mode):
+    assert mode in "fri"
+    op = fop if mode == "f" else "__" + mode + fop[2:]
+    helper = OP_HELPERS[fop]
+    op_func = getattr(operator, fop)
+    if mode == "r":
+
+        def wrapped_helper(u1, u2):
+            return helper(op_func, u2, u1)
+    else:
+
+        def wrapped_helper(u1, u2):
+            return helper(op_func, u1, u2)
+
+    def __op__(self, other):
+        return self._operate(other, op, wrapped_helper)
+
+    return __op__
+
+
+def _make_ops(op):
+    return tuple(_make_op(op, mode) for mode in "fri")
+
+
+def _make_comp(comp):
+    def __comp__(self, other):
+        try:
+            other = value_in_unit(other, self.unit)
+        except Exception:
+            return NotImplemented
+        return getattr(self.value, comp)(other)
+
+    return __comp__
+
+
+def _make_deferred(attr):
+    def deferred(self):
+        return getattr(self.value, attr)
+
+    return property(deferred)
+
+
+def _make_same_unit_method(attr):
+    def same_unit(self, *args, **kwargs):
+        return replace(self, value=getattr(self.value, attr)(*args, **kwargs))
+
+    return same_unit
+
+
+def _make_same_unit_attribute(attr):
+    def same_unit(self):
+        return replace(self, value=getattr(self.value, attr))
+
+    return property(same_unit)
+
+
+def _make_defer_dimensionless(attr):
+    def defer_dimensionless(self):
+        try:
+            return getattr(self.unit.to(DIMENSIONLESS, self.value), attr)()
+        except Exception as exc:
+            raise TypeError from exc
+
+    return defer_dimensionless
+
+
+def _check_pow_args(exp, mod):
+    if mod is not None:
+        return NotImplemented
+
+    if not isinstance(exp, PYTHON_NUMBER):
+        try:
+            exp = exp.__complex__()
+        except Exception:
+            try:
+                return exp.__float__()
+            except Exception:
+                return NotImplemented
+
+    return exp.real if exp.imag == 0 else exp
+
+
+@dataclass(frozen=True, eq=False)
+class Quantity:
+    value: Any
+    unit: u.UnitBase
+
+    def __array_namespace__(self, *, api_version: str | None = None) -> Any:
+        # TODO: make our own?
+        return np
+
+    def _operate(self, other, op, units_helper):
+        if not hasattr(other, "__array_namespace__") and not isinstance(
+            other, PYTHON_NUMBER
+        ):
+            # HACK: unit should take care of this!
+            if not isinstance(other, u.UnitBase):
+                return NotImplemented
+
+            try:
+                unit = getattr(operator, op)(self.unit, other)
+            except Exception:
+                return NotImplemented
+            else:
+                return replace(self, unit=unit)
+
+        other_value, other_unit = get_value_and_unit(other)
+        self_value = self.value
+        (conv0, conv1), unit = units_helper(self.unit, other_unit)
+        if conv0 is not None:
+            self_value = conv0(self_value)
+        if conv1 is not None:
+            other_value = conv1(other_value)
+        value = getattr(self_value, op)(other_value)
+        if value is NotImplemented:
+            return NotImplemented
+        return replace(self, value=value, unit=unit)
+
+    # Operators (skipping ones that make no sense, like __and__);
+    # __pow__ and __rpow__ need special treatment and are defined below.
+    __add__, __radd__, __iadd__ = _make_ops("__add__")
+    __floordiv__, __rfloordiv__, __ifloordiv__ = _make_ops("__floordiv__")
+    __matmul__, __rmatmul__, __imatmul__ = _make_ops("__matmul__")
+    __mod__, __rmod__, __imod__ = _make_ops("__mod__")
+    __mul__, __rmul__, __imul__ = _make_ops("__mul__")
+    __sub__, __rsub__, __isub__ = _make_ops("__sub__")
+    __truediv__, __rtruediv__, __itruediv__ = _make_ops("__truediv__")
+
+    # Comparisons
+    __eq__ = _make_comp("__eq__")
+    __ge__ = _make_comp("__ge__")
+    __gt__ = _make_comp("__gt__")
+    __le__ = _make_comp("__le__")
+    __lt__ = _make_comp("__lt__")
+    __ne__ = _make_comp("__ne__")
+
+    # Atttributes deferred to those of .value
+    dtype = _make_deferred("dtype")
+    device = _make_deferred("device")
+    ndim = _make_deferred("ndim")
+    shape = _make_deferred("shape")
+    size = _make_deferred("size")
+
+    # Deferred to .value, yielding new Quantity with same unit.
+    mT = _make_same_unit_attribute("mT")
+    T = _make_same_unit_attribute("T")
+    __abs__ = _make_same_unit_method("__abs__")
+    __neg__ = _make_same_unit_method("__neg__")
+    __pos__ = _make_same_unit_method("__pos__")
+    __getitem__ = _make_same_unit_method("__getitem__")
+    to_device = _make_same_unit_method("to_device")
+
+    # Deferred to .value, after making ourselves dimensionless (if possible).
+    __complex__ = _make_defer_dimensionless("__complex__")
+    __float__ = _make_defer_dimensionless("__float__")
+    __int__ = _make_defer_dimensionless("__int__")
+
+    # TODO: __dlpack__, __dlpack_device__
+
+    def __pow__(self, exp, mod=None):
+        exp = _check_pow_args(exp, mod)
+        if exp is NotImplemented:
+            return NotImplemented
+
+        value = self.value.__pow__(exp)
+        if value is NotImplemented:
+            return NotImplemented
+        return replace(self, value=value, unit=self.unit**exp)
+
+    def __ipow__(self, exp, mod=None):
+        exp = _check_pow_args(exp, mod)
+        if exp is NotImplemented:
+            return NotImplemented
+
+        value = self.value.__ipow__(exp)
+        if value is NotImplemented:
+            return NotImplemented
+        return replace(self, value=value, unit=self.unit**exp)
+
+    def __setitem__(self, item, value):
+        self.value[item] = value_in_unit(value, self.unit)
+
+    __array_ufunc__ = None
+    __array_function__ = None

--- a/quantity/tests/conftest.py
+++ b/quantity/tests/conftest.py
@@ -1,0 +1,62 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import annotations
+
+import array_api_compat
+import astropy.units as u
+import numpy as np
+from astropy.utils.decorators import classproperty
+
+ARRAY_NAMESPACES = []
+
+
+class ANSTests:
+    IMMUTABLE = False  # default
+
+    def __init_subclass__(cls, **kwargs):
+        # Add class to namespaces available for testing if the underlying
+        # array class is available.
+        if not cls.__name__.startswith("Test"):
+            try:
+                cls.xp  # noqa: B018
+            except ImportError:
+                pass
+            else:
+                ARRAY_NAMESPACES.append(cls)
+
+    @classmethod
+    def setup_class(cls):
+        cls.ARRAY_CLASS = type(cls.xp.ones((1,)))
+
+
+class UsingNDArray(ANSTests):
+    xp = np
+
+
+class MonkeyPatchUnitConversion:
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        # TODO: update astropy so this monkeypatch is not necessary!
+        # Enable non-coercing unit conversion on all astropy versions.
+        cls._old_condition_arg = u.core._condition_arg
+        u.core._condition_arg = lambda x: x
+
+    @classmethod
+    def teardown_class(cls):
+        u.core._condition_arg = cls._old_condition_arg
+
+
+class UsingArrayAPIStrict(MonkeyPatchUnitConversion, ANSTests):
+    @classproperty(lazy=True)
+    def xp(cls):
+        return __import__("array_api_strict")
+
+
+class UsingDask(MonkeyPatchUnitConversion, ANSTests):
+    IMMUTABLE = True
+
+    @classproperty(lazy=True)
+    def xp(cls):
+        import dask.array as da
+
+        return array_api_compat.array_namespace(da.array([1.0]))

--- a/quantity/tests/conftest.py
+++ b/quantity/tests/conftest.py
@@ -11,6 +11,7 @@ ARRAY_NAMESPACES = []
 
 class ANSTests:
     IMMUTABLE = False  # default
+    NO_SETITEM = False
 
     def __init_subclass__(cls, **kwargs):
         # Add class to namespaces available for testing if the underlying
@@ -60,3 +61,12 @@ class UsingDask(MonkeyPatchUnitConversion, ANSTests):
         import dask.array as da
 
         return array_api_compat.array_namespace(da.array([1.0]))
+
+
+class UsingJAX(MonkeyPatchUnitConversion, ANSTests):
+    IMMUTABLE = True
+    NO_SETITEM = True
+
+    @classproperty(lazy=True)
+    def xp(cls):
+        return __import__("jax").numpy

--- a/quantity/tests/test_class.py
+++ b/quantity/tests/test_class.py
@@ -1,0 +1,30 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Test the Quantity class Array API compatibility."""
+
+from __future__ import annotations
+
+from quantity import Quantity
+
+DEFER = {"dtype", "device", "ndim", "shape", "size"}
+SAME_UNIT = {"mT", "T", "__abs__", "__neg__", "__pos__", "__getitem__", "to_device"}
+implemented_ops = {"add", "floordiv", "matmul", "mod", "mul", "pow", "sub", "truediv"}
+OPERATORS = {f"__{typ}{op}__" for op in implemented_ops for typ in ("", "r", "i")}
+OPERATORS -= {"__rpow__"}
+COMPARISONS = {"__eq__", "__ge__", "__gt__", "__le__", "__lt__", "__ne__"}
+DEFER_DIMENSIONLESS = {"__complex__", "__float__", "__int__"}
+
+meaningless_ops = {"and", "invert", "lshift", "or", "rshift", "xor"}
+MEANINGLESS = {"__bool__", "__index__", "__rpow__"}
+MEANINGLESS |= {f"__{typ}{op}__" for op in meaningless_ops for typ in ("", "r", "i")}
+DLPACK = {"__dlpack__", "__dlpack_device__"}
+
+REQUIRED = DEFER | SAME_UNIT | OPERATORS | COMPARISONS | DEFER_DIMENSIONLESS | DLPACK
+NOT_YET_IMPLEMENTED = DLPACK
+
+
+class TestQuantityArrayApiCompatibility:
+    def test_method_compatibility(self):
+        assert set(Quantity.__dict__) > (REQUIRED - NOT_YET_IMPLEMENTED)
+
+    def test_no_meaningless_methods(self):
+        assert not MEANINGLESS.intersection(Quantity.__dict__)

--- a/quantity/tests/test_operations.py
+++ b/quantity/tests/test_operations.py
@@ -1,0 +1,298 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Test that operations on Quantity properly propagate units."""
+
+from __future__ import annotations
+
+import operator
+
+import astropy.units as u
+import numpy as np
+import pytest
+from numpy.testing import assert_array_almost_equal_nulp, assert_array_equal
+
+from quantity import Quantity
+
+
+def assert_quantity_equal(q1, q2, nulp=0):
+    assert q1.unit == q2.unit
+    assert_array_almost_equal_nulp(q1.value, q2.value, nulp=nulp)
+
+
+class QuantitySetup:
+    @classmethod
+    def setup_class(cls):
+        cls.a1 = np.arange(1.0, 11.0).reshape(5, 2)
+        cls.a2 = np.array([8.0, 10.0])
+        cls.q1 = Quantity(cls.a1, u.meter)
+        cls.q2 = Quantity(cls.a2, u.centimeter)
+
+
+class TestQuantityOperations(QuantitySetup):
+    def test_addition(self):
+        # Take units from left object, q1
+        got = self.q1 + self.q2
+        exp = Quantity(self.q1.value + self.q2.value / 100.0, u.m)
+        assert_quantity_equal(got, exp, nulp=1)
+        # Take units from left object, q2
+        got = self.q2 + self.q1
+        exp = Quantity(self.q1.value * 100 + self.q2.value, u.cm)
+        assert_quantity_equal(got, exp, nulp=1)
+
+    def test_subtraction(self):
+        # Take units from left object, q1
+        got = self.q1 - self.q2
+        exp = Quantity(self.q1.value - self.q2.value / 100.0, u.m)
+        assert_quantity_equal(got, exp, nulp=1)
+
+        # Take units from left object, q2
+        got = self.q2 - self.q1
+        exp = Quantity(self.q2.value - 100.0 * self.q1.value, u.cm)
+        assert_quantity_equal(got, exp, nulp=1)
+
+    def test_multiplication(self):
+        got = self.q1 * self.q2
+        exp = Quantity(self.q1.value * self.q2.value, u.Unit("m cm"))
+        assert_quantity_equal(got, exp)
+        got = self.q2 * self.q1
+        assert_quantity_equal(got, exp)
+
+    def test_multiplication_with_number(self):
+        got = 15.0 * self.q1
+        exp = Quantity(15.0 * self.q1.value, u.m)
+        assert_quantity_equal(got, exp)
+        got = self.q1 * 15.0
+        assert_quantity_equal(got, exp)
+
+    def test_multiplication_with_unit(self):
+        got = self.q1 * u.s
+        exp = Quantity(self.q1.value, u.Unit("m s"))
+        assert_quantity_equal(got, exp)
+        got = u.s * self.q1
+        assert_quantity_equal(got, exp)
+
+    def test_division(self):
+        got = self.q1 / self.q2
+        exp = Quantity(self.q1.value / self.q2.value, u.Unit("m/cm"))
+        assert_quantity_equal(got, exp)
+        got = self.q2 / self.q1
+        exp = Quantity(self.q2.value / self.q1.value, u.Unit("cm/m"))
+        assert_quantity_equal(got, exp)
+
+    def test_division_with_number(self):
+        got = self.q1 / 10.0
+        exp = Quantity(self.q1.value / 10.0, u.m)
+        assert_quantity_equal(got, exp)
+        got = 11.0 / self.q1
+        exp = Quantity(11.0 / self.q1.value, u.m**-1)
+        assert_quantity_equal(got, exp)
+
+    def test_division_with_unit(self):
+        got = self.q1 / u.s
+        exp = Quantity(self.q1.value, u.Unit("m/s"))
+        assert_quantity_equal(got, exp)
+        # Divide into a unit.
+        got = u.s / self.q1
+        exp = Quantity(1 / self.q1.value, u.Unit("s/m"))
+        assert_quantity_equal(got, exp)
+
+    def test_floor_division(self):
+        got = self.q1 // self.q2
+        exp = Quantity(self.q1.value // (0.01 * self.q2.value), u.one)
+        assert_quantity_equal(got, exp)
+        got = self.q2 // self.q1
+        exp = Quantity(self.q2.value // (100.0 * self.q1.value), u.one)
+        assert_quantity_equal(got, exp)
+
+    def test_floor_division_errors(self):
+        q2 = Quantity(self.a1, u.s)
+        with pytest.raises(u.UnitsError, match="[Cc]an only apply 'floordiv'"):
+            self.q1 // q2
+        with pytest.raises(TypeError):
+            self.q1 // u.s
+
+    def test_mod(self):
+        got = self.q1 % self.q2
+        exp = Quantity(self.q1.value % (0.01 * self.q2.value), self.q1.unit)
+        assert_quantity_equal(got, exp)
+        got = self.q2 % self.q1
+        exp = Quantity(self.q2.value % (100.0 * self.q1.value), self.q2.unit)
+        assert_quantity_equal(got, exp)
+
+    def test_floor_div_mod_roundtrip(self):
+        got = self.q1 % self.q2 + (self.q1 // self.q2) * self.q2
+        assert_quantity_equal(got, self.q1, nulp=1)
+        got = self.q2 % self.q1 + (self.q2 // self.q1) * self.q1
+        assert_quantity_equal(got, self.q2, nulp=1)
+
+    def test_power(self):
+        # raise quantity to a power
+        got = self.q1**2
+        exp = Quantity(self.q1.value**2, u.Unit("m^2"))
+        assert_quantity_equal(got, exp)
+        got = self.q1**3
+        exp = Quantity(self.q1.value**3, u.Unit("m^3"))
+        assert_quantity_equal(got, exp)
+
+    @pytest.mark.parametrize(
+        "exponent",
+        [2, 2.0, np.uint64(2), np.int32(2), np.float32(2), Quantity(2.0, u.one)],
+    )
+    def test_quantity_as_power(self, exponent):
+        # raise unit to a dimensionless Quantity power
+        got = self.q1**exponent
+        exp = Quantity(self.q1.value**2, u.m**2)
+        assert_quantity_equal(got, exp)
+
+    def test_matmul(self):
+        a = np.eye(3)
+        q = Quantity(a, u.m)
+        got = q @ a
+        exp = Quantity(a, u.m)
+        assert_quantity_equal(got, exp)
+        got = a @ q
+        assert_quantity_equal(got, exp)
+        got = q @ q
+        exp = Quantity(a, u.m**2)
+        assert_quantity_equal(got, exp)
+        a2 = np.array(
+            [[[1., 0., 0.],
+              [0., 1., 0.],
+              [0., 0., 1.]],
+             [[0., 1., 0.],
+              [0., 0., 1.],
+              [1., 0., 0.]],
+             [[0., 0., 1.],
+              [1., 0., 0.],
+              [0., 1., 0.]]]
+        )  # fmt: skip
+        q2 = Quantity(a2, u.s**-1)
+        got = q @ q2
+        exp = Quantity(q.value @ q2.value, u.Unit("m/s"))
+        assert_quantity_equal(got, exp)
+
+    def test_negative(self):
+        got = -self.q1
+        exp = Quantity(-self.q1.value, u.m)
+        assert_quantity_equal(got, exp)
+
+        got = -(-self.q1)  # noqa: B002
+        assert_quantity_equal(got, self.q1)
+
+    def test_positive(self):
+        got = +self.q1
+        assert_quantity_equal(got, self.q1)
+
+    def test_abs(self):
+        got = abs(self.q1)
+        exp = Quantity(abs(self.q1.value), u.m)
+        assert_quantity_equal(got, exp)
+        got = abs(-self.q1)
+        exp = Quantity(abs(self.q1.value), u.m)
+        assert_quantity_equal(got, exp)
+
+    def test_incompatible_units(self):
+        """Raise when trying to add or subtract incompatible units"""
+        q = Quantity(21.52, unit=u.second)
+        with pytest.raises(u.UnitsError, match="[Cc]an only apply 'add' function"):
+            self.q1 + q
+
+    def test_non_number_type(self):
+        with pytest.raises(TypeError, match=r"[Uu]nsupported operand type\(s\).*"):
+            self.q1 + {"a": 1}
+
+        with pytest.raises(TypeError):
+            self.q1 + u.meter
+
+        with pytest.raises(TypeError):
+            self.q1 * u.mag(u.Jy)
+
+    def test_dimensionless_operations(self):
+        q1 = Quantity(self.a1, u.m / u.km)
+        q2 = Quantity(self.a2, u.mm / u.km)
+        got = q1 + q2
+        exp = Quantity(q1.value + q2.value / 1000.0, q1.unit)
+        assert_quantity_equal(got, exp, nulp=1)
+        # Test plain float.
+        got = q1 + 1.0
+        exp = Quantity(q1.value / 1000.0 + 1.0, u.one)
+        assert_quantity_equal(got, exp, nulp=1)
+        # Test integers too.
+        got = q1 + np.ones(self.a2.shape, int)
+        assert_quantity_equal(got, exp, nulp=1)
+
+    def test_dimensionless_error(self):
+        with pytest.raises(u.UnitsError):
+            self.q1 + Quantity(self.a1, unit=u.one)
+
+        with pytest.raises(u.UnitsError):
+            self.q1 - Quantity(self.a1, unit=u.one)
+
+    def test_eq_ne(self):
+        # equality/ non-equality is straightforward for quantity objects
+        q = Quantity(self.q1.value * 100.0, u.cm)
+        got = self.q1 == q
+        assert got.shape == self.q1.shape
+        assert_array_equal(got, True)
+        got = self.q1 != q
+        assert_array_equal(got, False)
+        q = Quantity(self.q1.value * 10.0, u.cm)
+        got = self.q1 == q
+        assert_array_equal(got, False)
+        got = self.q1 != q
+        assert_array_equal(got, True)
+
+    def test_not_equal_to_unit(self):
+        # This should not work (unlike for astropy Quantity)
+        unit = u.cm**3
+        q = Quantity(np.array([1.0]), unit)
+        assert q != unit
+
+    @pytest.mark.parametrize(
+        ("value", "unit"),
+        [(1.0, u.cm), (1.0, u.one), (0.0, u.cm), (0.0, u.one)],
+    )
+    def test_always_truthy(self, value, unit):
+        q = Quantity(np.array(value), unit)
+        assert bool(q)  # default python behaviour when __bool__ is not present.
+
+    @pytest.mark.parametrize(("value", "unit"), [(1.23, u.one), (1.1, u.m / u.km)])
+    def test_numeric_converters(self, value, unit):
+        # float and int should only work for scalar dimensionless quantities.
+        q = Quantity(np.array(value), unit)
+        assert float(q) == float(q.unit.to(u.one, q.value))
+        assert int(q) == int(q.unit.to(u.one, q.value))
+
+        with pytest.raises(TypeError):
+            operator.index(q)
+
+    def test_numeric_converters_fail_on_non_dimenionless(self):
+        q = Quantity(np.array(1.0), u.m)
+        with pytest.raises(TypeError):
+            float(q)
+        with pytest.raises(TypeError):
+            int(q)
+
+    def test_numeric_converters_fail_on_non_scalar(self):
+        q = Quantity(np.array([1, 2]), u.m)
+        with pytest.raises(TypeError):
+            float(q)
+        with pytest.raises(TypeError):
+            int(q)
+
+    @pytest.mark.parametrize("value", [np.array(1.0), np.arange(10.0)])
+    def test_inplace(self, value):
+        s = Quantity(value.copy(), u.cycle)
+        check = s
+        s /= 2.0
+        assert check.value is s.value
+        exp = Quantity(value / 2.0, u.cycle)
+        assert_quantity_equal(s, exp)
+        s /= u.s
+        assert check.value is s.value
+        # Choice for making Quantity itself immutable.
+        assert check.unit == u.cycle
+        assert s.unit == u.cycle / u.s
+        s *= Quantity(2.0, u.s)
+        exp = Quantity(value, u.cycle)
+        assert check.value is s.value
+        assert_quantity_equal(s, exp)

--- a/quantity/tests/test_quantity.py
+++ b/quantity/tests/test_quantity.py
@@ -146,6 +146,8 @@ class QuantityMethodTests(QuantityTestSetup):
     def test_setitem(self):
         # Create explicitly to ensure we do not change self.q1.
         q = Quantity(self.xp.asarray(np.arange(10.0).reshape(5, 2)), self.q.unit)
+        if self.NO_SETITEM:
+            pytest.xfail(reason=f"array type {self.xp!r} elements cannot be set")
         q[:2, :] = Quantity(200.0, u.cm)
         assert q.unit is self.q.unit
         assert_array_equal(q.value[:2, :], 2.0)

--- a/quantity/tests/test_quantity.py
+++ b/quantity/tests/test_quantity.py
@@ -1,10 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Test the Quantity class, creation and basic methods."""
+"""Test the Quantity class, creation and basic methods.
+
+Note: tests classes are combined with setups for different array types
+at the very end.  Hence, they do not have the usual Test prefix.
+"""
 
 from __future__ import annotations
 
 import copy
 
+import array_api_compat
 import astropy.units as u
 import numpy as np
 import pytest
@@ -12,32 +17,47 @@ from numpy.testing import assert_array_equal
 
 from quantity import Quantity
 
+from .conftest import ARRAY_NAMESPACES
 
-class TestQuantityCreation:
+
+class QuantityCreationTests:
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.value = cls.xp.arange(10.0)
+        cls.unit = u.m
+        cls.ARRAY_CLASS = type(cls.value)
+
+    def test_setup(self):
+        try:
+            xp = self.value.__array_namespace__()
+        except AttributeError:
+            xp = array_api_compat.array_namespace(self.value)
+
+        assert self.xp is xp
+
     def test_initializer(self):
         # create objects using the Quantity constructor:
-        value = np.arange(3.0)
-        unit = u.m
-        q = Quantity(value, unit)
-        assert q.value is value
-        assert q.unit is unit
-        q2 = Quantity(value=value, unit=unit)
-        assert q2.value is value
-        assert q2.unit is u.m
+        q = Quantity(self.value, self.unit)
+        assert q.value is self.value
+        assert q.unit is self.unit
+        q2 = Quantity(value=self.value, unit=self.unit)
+        assert q2.value is self.value
+        assert q2.unit is self.unit
 
     def test_need_value(self):
         with pytest.raises(TypeError):
-            Quantity(unit=u.m)
+            Quantity(unit=self.unit)
 
     def test_need_unit(self):
         with pytest.raises(TypeError):
-            Quantity(np.array([3.0]))
+            Quantity(self.value)
 
     def test_value_unit_immutable(self):
-        q = Quantity(np.array([11.0]), unit=u.meter)
+        q = Quantity(self.value, unit=self.unit)
 
         with pytest.raises(AttributeError):
-            q.value = np.array([10.0])
+            q.value = self.xp.asarray([10.0])
 
         with pytest.raises(AttributeError):
             q.unit = u.cm
@@ -46,31 +66,39 @@ class TestQuantityCreation:
 class QuantityTestSetup:
     @classmethod
     def setup_class(cls):
-        cls.q = Quantity(np.arange(10.0).reshape(5, 2), u.meter)
+        super().setup_class()
+        cls.a = cls.xp.asarray(np.arange(10.0).reshape(5, 2))
+        cls.q = Quantity(cls.a, u.meter)
 
 
-class TestQuantityAttributes(QuantityTestSetup):
+class QuantityAttributeTests(QuantityTestSetup):
     """Should follow Array API:
     https://data-apis.org/array-api/latest/API_specification/array_object.html#attributes
     """
 
     def test_deferred_to_value(self):
         value = self.q.value
+        assert type(value) is self.ARRAY_CLASS
         assert self.q.shape == value.shape
         assert self.q.size == value.size
         assert self.q.ndim == value.ndim
         assert self.q.dtype == value.dtype
-        assert self.q.device == value.device
+        assert self.q.device == array_api_compat.device(value)
 
     @pytest.mark.parametrize("transpose", ["mT", "T"])
     def test_transpose(self, transpose):
+        try:
+            getattr(self.a, transpose)
+        except AttributeError:
+            pytest.xfail(reason=f"{self.xp!r} does not have .{transpose}.")
         q_t = getattr(self.q, transpose)
         assert q_t.unit is self.q.unit
+        assert type(q_t.value) is self.ARRAY_CLASS
         expected = getattr(self.q.value, transpose)
         assert_array_equal(q_t.value, expected)
 
 
-class TestCopy(QuantityTestSetup):
+class QuantityCopyTests(QuantityTestSetup):
     def test_copy(self):
         q_copy = copy.copy(self.q)
         assert q_copy is not self.q
@@ -78,14 +106,19 @@ class TestCopy(QuantityTestSetup):
         assert q_copy.unit is self.q.unit
 
     def test_deepcopy(self):
+        try:
+            copy.deepcopy(self.a)
+        except TypeError:
+            pytest.xfail(reason="cannot deepcopy {self.xp!r}.")
         q_dc = copy.deepcopy(self.q)
         assert q_dc is not self.q
+        assert type(q_dc.value) is self.ARRAY_CLASS
         assert q_dc.value is not self.q.value
         assert q_dc.unit is self.q.unit  # u.m is always the same
         assert_array_equal(q_dc.value, self.q.value)
 
 
-class TestQuantityMethods(QuantityTestSetup):
+class QuantityMethodTests(QuantityTestSetup):
     """Test non-operator methods (for those, see test_operations).
     https://data-apis.org/array-api/latest/API_specification/array_object.html#methods
     This leaves:
@@ -103,20 +136,34 @@ class TestQuantityMethods(QuantityTestSetup):
         assert self.q.__array_namespace__() is np
 
     def test_getitem(self):
-        q2 = self.q[:2]
+        q2 = self.q[:2, :]  # Note Array API: need to specify both
         assert isinstance(q2, Quantity)
+        assert type(q2.value) is self.ARRAY_CLASS
         assert q2.unit == u.meter
         assert q2.shape == (2, 2)
-        assert_array_equal(q2.value, self.q.value[:2])
+        assert_array_equal(q2.value, self.q.value[:2, :])
 
     def test_setitem(self):
-        q = copy.deepcopy(self.q)
-        q[:2] = Quantity(200.0, u.cm)
+        # Create explicitly to ensure we do not change self.q1.
+        q = Quantity(self.xp.asarray(np.arange(10.0).reshape(5, 2)), self.q.unit)
+        q[:2, :] = Quantity(200.0, u.cm)
         assert q.unit is self.q.unit
-        assert_array_equal(q.value[:2], 2.0)
-        assert_array_equal(q.value[2:], self.q.value[2:])
+        assert_array_equal(q.value[:2, :], 2.0)
+        assert_array_equal(q.value[2:, :], self.q.value[2:, :])
 
     def test_to_device(self):
-        q = self.q.to_device("cpu")
+        q = self.q.to_device(self.q.device)
         assert q.unit is self.q.unit
         assert_array_equal(q.value, self.q.value)
+
+
+# Create the actual test classes.
+for base_setup in ARRAY_NAMESPACES:
+    for tests in (
+        QuantityCreationTests,
+        QuantityAttributeTests,
+        QuantityCopyTests,
+        QuantityMethodTests,
+    ):
+        name = f"Test{tests.__name__}{base_setup.__name__}"
+        globals()[name] = type(name, (tests, base_setup), {})

--- a/quantity/tests/test_quantity.py
+++ b/quantity/tests/test_quantity.py
@@ -1,0 +1,122 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Test the Quantity class, creation and basic methods."""
+
+from __future__ import annotations
+
+import copy
+
+import astropy.units as u
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from quantity import Quantity
+
+
+class TestQuantityCreation:
+    def test_initializer(self):
+        # create objects using the Quantity constructor:
+        value = np.arange(3.0)
+        unit = u.m
+        q = Quantity(value, unit)
+        assert q.value is value
+        assert q.unit is unit
+        q2 = Quantity(value=value, unit=unit)
+        assert q2.value is value
+        assert q2.unit is u.m
+
+    def test_need_value(self):
+        with pytest.raises(TypeError):
+            Quantity(unit=u.m)
+
+    def test_need_unit(self):
+        with pytest.raises(TypeError):
+            Quantity(np.array([3.0]))
+
+    def test_value_unit_immutable(self):
+        q = Quantity(np.array([11.0]), unit=u.meter)
+
+        with pytest.raises(AttributeError):
+            q.value = np.array([10.0])
+
+        with pytest.raises(AttributeError):
+            q.unit = u.cm
+
+
+class QuantityTestSetup:
+    @classmethod
+    def setup_class(cls):
+        cls.q = Quantity(np.arange(10.0).reshape(5, 2), u.meter)
+
+
+class TestQuantityAttributes(QuantityTestSetup):
+    """Should follow Array API:
+    https://data-apis.org/array-api/latest/API_specification/array_object.html#attributes
+    """
+
+    def test_deferred_to_value(self):
+        value = self.q.value
+        assert self.q.shape == value.shape
+        assert self.q.size == value.size
+        assert self.q.ndim == value.ndim
+        assert self.q.dtype == value.dtype
+        assert self.q.device == value.device
+
+    @pytest.mark.parametrize("transpose", ["mT", "T"])
+    def test_transpose(self, transpose):
+        q_t = getattr(self.q, transpose)
+        assert q_t.unit is self.q.unit
+        expected = getattr(self.q.value, transpose)
+        assert_array_equal(q_t.value, expected)
+
+
+class TestCopy(QuantityTestSetup):
+    def test_copy(self):
+        q_copy = copy.copy(self.q)
+        assert q_copy is not self.q
+        assert q_copy.value is self.q.value
+        assert q_copy.unit is self.q.unit
+
+    def test_deepcopy(self):
+        q_dc = copy.deepcopy(self.q)
+        assert q_dc is not self.q
+        assert q_dc.value is not self.q.value
+        assert q_dc.unit is self.q.unit  # u.m is always the same
+        assert_array_equal(q_dc.value, self.q.value)
+
+
+class TestQuantityMethods(QuantityTestSetup):
+    """Test non-operator methods (for those, see test_operations).
+    https://data-apis.org/array-api/latest/API_specification/array_object.html#methods
+    This leaves:
+    __array_namespace__
+    __getitem__
+    __setitem__
+    to_device
+
+    TODO: implemented and test the following
+    __dlpack__
+    __dlpack_device__
+    """
+
+    def test_array_namespace(self):
+        assert self.q.__array_namespace__() is np
+
+    def test_getitem(self):
+        q2 = self.q[:2]
+        assert isinstance(q2, Quantity)
+        assert q2.unit == u.meter
+        assert q2.shape == (2, 2)
+        assert_array_equal(q2.value, self.q.value[:2])
+
+    def test_setitem(self):
+        q = copy.deepcopy(self.q)
+        q[:2] = Quantity(200.0, u.cm)
+        assert q.unit is self.q.unit
+        assert_array_equal(q.value[:2], 2.0)
+        assert_array_equal(q.value[2:], self.q.value[2:])
+
+    def test_to_device(self):
+        q = self.q.to_device("cpu")
+        assert q.unit is self.q.unit
+        assert_array_equal(q.value, self.q.value)


### PR DESCRIPTION
Support for `numpy`, `array-api-strict`, `dask`, and `jax`, with basic tests for all ~, and ufuncs for `numpy` only. Pushing now in part to check whether CI works properly.~

EDIT: I pushed a version that does not yet include numpy ufuncs, but for which the basics are now tested more thoroughly.