### PR TITLE
💄: rm isort auto-adding future import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-quantity/_version.py
+src/quantity/_version.py
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,9 +142,6 @@ ignore = [
   "PLR2004",  # Magic value used in comparison
   "RET505",   # Unnecessary `else`/`elif` after `return` statement
 ]
-isort.required-imports = ["from __future__ import annotations"]
-# Uncomment if using a _compat.typing backport
-# typing-modules = ["quantity_2_0._compat.typing"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["T20"]

--- a/src/quantity/__init__.py
+++ b/src/quantity/__init__.py
@@ -4,8 +4,6 @@ Copyright (c) 2024 Astropy Developers. All rights reserved.
 quantity-2.0: Prototyping the next generation Quantity
 """
 
-from __future__ import annotations
-
 from .core import Quantity
 from .version import version as __version__  # noqa: F401
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import annotations
 
 import array_api_compat
 import astropy.units as u

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Test the Quantity class Array API compatibility."""
 
-from __future__ import annotations
-
 from quantity import Quantity
 
 DEFER = {"dtype", "device", "ndim", "shape", "size"}

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -5,8 +5,6 @@ Note: tests classes are combined with setups for different array types
 at the very end.  Hence, they do not have the usual Test prefix.
 """
 
-from __future__ import annotations
-
 import operator
 
 import astropy.units as u

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -5,8 +5,6 @@ Note: tests classes are combined with setups for different array types
 at the very end.  Hence, they do not have the usual Test prefix.
 """
 
-from __future__ import annotations
-
 import copy
 
 import array_api_compat


### PR DESCRIPTION
We shouldn’t be afraid to use `from __future__ import annotations`, but should avoid adding it unnecessarily.