### PR TITLE
🏗️: walled garden of private API

### DIFF
--- a/src/quantity/__init__.py
+++ b/src/quantity/__init__.py
@@ -1,10 +1,9 @@
-"""
+"""Quantity-2.0: Prototyping the next generation Quantity.
+
 Copyright (c) 2024 Astropy Developers. All rights reserved.
-
-quantity-2.0: Prototyping the next generation Quantity
 """
 
-from .core import Quantity
+from ._src import Quantity
 from .version import version as __version__  # noqa: F401
 
 __all__ = ["Quantity"]

--- a/src/quantity/_src/__init__.py
+++ b/src/quantity/_src/__init__.py
@@ -1,0 +1,13 @@
+"""Quantity 2.0.
+
+This `_src` module implements the private API.
+The public API is available in the top-level `quantity` module.
+
+"""
+# Copyright (c) 2024 Astropy Developers. All rights reserved.
+
+from __future__ import annotations
+
+from .core import Quantity
+
+__all__ = ["Quantity"]

--- a/src/quantity/_src/__init__.py
+++ b/src/quantity/_src/__init__.py
@@ -6,8 +6,6 @@ The public API is available in the top-level `quantity` module.
 """
 # Copyright (c) 2024 Astropy Developers. All rights reserved.
 
-from __future__ import annotations
-
 from .core import Quantity
 
 __all__ = ["Quantity"]

--- a/src/quantity/_src/core.py
+++ b/src/quantity/_src/core.py
@@ -10,6 +10,8 @@ import astropy.units as u
 import numpy as np
 from astropy.units.quantity_helper import UFUNC_HELPERS
 
+from .utils import has_array_namespace
+
 if TYPE_CHECKING:
     from typing import Any
 
@@ -17,15 +19,6 @@ if TYPE_CHECKING:
 DIMENSIONLESS = u.dimensionless_unscaled
 
 PYTHON_NUMBER = float | int | complex
-
-
-def has_array_namespace(arg):
-    try:
-        array_api_compat.array_namespace(arg)
-    except TypeError:
-        return False
-    else:
-        return True
 
 
 def get_value_and_unit(arg, default_unit=None):

--- a/src/quantity/_src/utils.py
+++ b/src/quantity/_src/utils.py
@@ -1,7 +1,5 @@
 """Utility functions for the quantity package."""
 
-from __future__ import annotations
-
 import array_api_compat
 
 

--- a/src/quantity/_src/utils.py
+++ b/src/quantity/_src/utils.py
@@ -1,0 +1,14 @@
+"""Utility functions for the quantity package."""
+
+from __future__ import annotations
+
+import array_api_compat
+
+
+def has_array_namespace(arg: object) -> bool:
+    try:
+        array_api_compat.array_namespace(arg)
+    except TypeError:
+        return False
+    else:
+        return True

--- a/src/quantity/version.py
+++ b/src/quantity/version.py
@@ -1,11 +1,12 @@
 # NOTE: First try _dev.scm_version if it exists and setuptools_scm is installed
 # This file is not included in wheels/tarballs, so otherwise it will
 # fall back on the generated _version module.
+version: str
 try:
     try:
         from ._dev.scm_version import version
     except ImportError:
-        from ._version import version
+        from ._version import version # type: ignore[no-redef]
 except Exception:
     import warnings
 


### PR DESCRIPTION
Also moving a utility function, without making it public.

This PR shows how we can separate the public from private API, enabling easy dev on the private API without impacting the public API.

Closes #9 