### PR TITLE
BLD: simplify build dependencies, drop `setup.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ repository = "https://github.com/astropy/quantity-2.0"
 
 [build-system]
 requires = [
-  "setuptools>=62.1",
+  "setuptools>=64.0",
   "setuptools_scm[toml]>=6.2",
-  "wheel",]
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
A small fly-by contribution:
- `setup.py` is not required at all with setuptools>=64 (see the first note from https://setuptools.pypa.io/en/latest/references/keywords.html#keywords)
- `wheel` doesn't need to be specified as a build time dependency; setuptools already pulls it in as needed (see second note from https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use)